### PR TITLE
Use MIT license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,9 +1,9 @@
-Copyright (c) 2021-present Shopify Inc.
+MIT License
+
+Copyright (c) 2021-present, Shopify Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-The rights granted above may only be exercised to develop and distribute applications that integrate or interoperate with Shopify software or services, and in the case of external, stand-alone applications that do not embed directly inside Shopify, the rights granted above may only be exercised to develop and distribute applications that are dissimilar and visually distinct from Shopify products and services (including the internal administration page of a Shopify merchant store), as determined by Shopify in its sole discretion.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Previously had the custom Polaris license which added an additional clause regarding building admin-like experiences using the library. However, that is not really possible with this library alone, and Polaris is a peer dependency of `@shopify/channels-ui` so consumers will need to follow the custom license anyways.